### PR TITLE
Add fallback config and example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 2. ``pip install Swarm``
 3. ``pip install playwright swarm openai beautifulsoup4``
 4. ``playwright install``
+
+### Configuration
+Copy `config.example.py` to `config.py` and fill in your InfluxDB details. If no
+`config.py` is present, the application falls back to the environment variables
+`INFLUX_URL`, `INFLUX_TOKEN`, `INFLUX_ORG` and `INFLUX_BUCKET`.

--- a/agents.py
+++ b/agents.py
@@ -1,8 +1,16 @@
-from config import INFLUX_URL, INFLUX_TOKEN, INFLUX_ORG, INFLUX_BUCKET
+import os
+
+try:
+    from config import INFLUX_URL, INFLUX_TOKEN, INFLUX_ORG, INFLUX_BUCKET
+except ImportError:
+    INFLUX_URL = os.getenv("INFLUX_URL")
+    INFLUX_TOKEN = os.getenv("INFLUX_TOKEN")
+    INFLUX_ORG = os.getenv("INFLUX_ORG")
+    INFLUX_BUCKET = os.getenv("INFLUX_BUCKET")
+
 from swarm import Swarm, Agent
 from openai import OpenAI
 import influxdb_client
-import os
 import pandas as pd
 import matplotlib.pyplot as plt
 

--- a/config.example.py
+++ b/config.example.py
@@ -1,0 +1,13 @@
+import os
+
+# Default InfluxDB Configuration values
+DEFAULT_INFLUX_URL = "https://example.com"
+DEFAULT_INFLUX_TOKEN = "example-token"
+DEFAULT_INFLUX_ORG = "example-org"
+DEFAULT_INFLUX_BUCKET = "example-bucket"
+
+# InfluxDB Configuration with environment variables and fallback to default values
+INFLUX_URL = os.getenv("INFLUX_URL", DEFAULT_INFLUX_URL)
+INFLUX_TOKEN = os.getenv("INFLUX_TOKEN", DEFAULT_INFLUX_TOKEN)
+INFLUX_ORG = os.getenv("INFLUX_ORG", DEFAULT_INFLUX_ORG)
+INFLUX_BUCKET = os.getenv("INFLUX_BUCKET", DEFAULT_INFLUX_BUCKET)


### PR DESCRIPTION
## Summary
- allow agents to fall back to environment variables if `config.py` is missing
- provide `config.example.py` with placeholder values
- document configuration in `README.md`

## Testing
- `python -m py_compile agents.py main.py config.example.py`

------
https://chatgpt.com/codex/tasks/task_e_6850769ac9d88332b69401eb7ae60e54