### PR TITLE
Add clarifying agent for interactive questions

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -280,6 +280,23 @@ data_specialist_agent = Agent(
     model=MODEL_NAME,
 )
 
+# ---------- Clarifying agent ----------
+
+def ask_user(question: str) -> str:
+    """Prompt the user for additional information."""
+    return input(f"{question}\n> ")
+
+
+clarifying_agent = Agent(
+    name="Clarifying Agent",
+    instructions=(
+        "You help gather missing details. "
+        "Whenever you need more information, call the ask_user function to pose a question to the user."
+    ),
+    functions=[ask_user],
+    model=MODEL_NAME,
+)
+
 # ---------- Triage agent ----------
 
 triage_agent = Agent(
@@ -305,8 +322,17 @@ def transfer_to_data_specialist():
     return data_specialist_agent
 
 
+def transfer_to_clarifying_agent():
+    """Transfer the conversation to the Clarifying agent."""
+    return clarifying_agent
+
+
 triage_agent.functions = [
-    transfer_to_database_manager, transfer_to_data_specialist]
+    transfer_to_database_manager,
+    transfer_to_data_specialist,
+    transfer_to_clarifying_agent,
+]
 influxDB_agent.functions.append(transfer_back_to_triage)
 influxDB_agent.functions.append(transfer_to_data_specialist)
 data_specialist_agent.functions.append(transfer_back_to_triage)
+clarifying_agent.functions.append(transfer_back_to_triage)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -81,3 +81,19 @@ def test_influx_list_fields_uses_predicate():
 
         called_query = mock_query_api.query.call_args.kwargs['query']
         assert 'predicate: (r) => r._measurement == "my_measure"' in called_query
+
+
+def test_ask_user_reads_input():
+    with patch('builtins.input', return_value='42'):
+        import agents
+        importlib.reload(agents)
+
+        result = agents.ask_user('How many?')
+        assert result == '42'
+
+
+def test_clarifying_agent_has_function():
+    import agents
+    importlib.reload(agents)
+
+    assert agents.ask_user in agents.clarifying_agent.functions


### PR DESCRIPTION
## Summary
- extend agents with a clarifying agent that can ask the user questions
- hook clarifying agent into the triage flow
- test new ask_user helper and agent configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ac0beb7c83328f9db5c41c6ee8fc