### PR TITLE
Add user-satisfaction prompts to all agents

### DIFF
--- a/agents/clarifying_agent.py
+++ b/agents/clarifying_agent.py
@@ -11,7 +11,8 @@ clarifying_agent = Agent(
     name="Clarifying Agent",
     instructions=(
         "You help gather missing details. "
-        "Whenever you need more information, call the ask_user function to pose a question to the user."
+        "Whenever you need more information, call the ask_user function to pose a question to the user. "
+        "After responding, always ask if the user needs anything else or if everything is clear."
     ),
     functions=[ask_user],
     model=MODEL_NAME,

--- a/agents/data_specialist_agent.py
+++ b/agents/data_specialist_agent.py
@@ -102,7 +102,7 @@ data_specialist_agent = Agent(
     instructions=(
         "You are a data specialist agent. You can list data fields, filter datasets based on criteria, "
         "and autonomously decide which data to visualize. You generate plot files when requested, "
-        "supporting scatter, line, bar, histogram and pie charts."
+        "supporting scatter, line, bar, histogram and pie charts. After delivering your output, ask the user if they need anything else or if the results meet their needs."
     ),
     functions=[
         list_data_fields,

--- a/agents/database_manager.py
+++ b/agents/database_manager.py
@@ -155,7 +155,7 @@ influxDB_agent = Agent(
     instructions=(
         "You are an IT specialist agent capable of managing and querying an InfluxDB database. "
         "You can list buckets, measurements, fields, query the last hour of data, execute arbitrary Flux queries, "
-        "write points, and delete data."
+        "write points, and delete data. After completing a task, ask the user if they need anything else or if the result is satisfactory."
     ),
     functions=[
         influx_list_buckets,

--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -27,7 +27,10 @@ def transfer_to_clarifying_agent():
 
 triage_agent = Agent(
     name="Triage Agent",
-    instructions="Determine which agent is best suited to handle the user's request, and transfer the conversation to that agent.",
+    instructions=(
+        "Determine which agent is best suited to handle the user's request, and transfer the conversation to that agent. "
+        "After providing guidance, ask the user if they need anything else."
+    ),
     model=MODEL_NAME,
 )
 


### PR DESCRIPTION
## Summary
- update `clarifying_agent` instructions to always ask if anything else is needed
- update `database_manager` instructions with follow-up question
- update `data_specialist_agent` instructions with follow-up question
- update `triage_agent` instructions with follow-up question

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d6ea9964833295eb469192e53a24