### PR TITLE
Add clarifying loop to triage flow

### DIFF
--- a/agents/clarifying_agent.py
+++ b/agents/clarifying_agent.py
@@ -10,8 +10,8 @@ def ask_user(question: str) -> str:
 clarifying_agent = Agent(
     name="Clarifying Agent",
     instructions=(
-        "You help gather missing details. "
-        "Whenever you need more information, call the ask_user function to pose a question to the user."
+        "You help gather missing details and check if the user has further requests. "
+        "Whenever more information is needed or a conversation ends, call the ask_user function to interact with the user."
     ),
     functions=[ask_user],
     model=MODEL_NAME_1,

--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -27,7 +27,10 @@ def transfer_to_clarifying_agent():
 
 triage_agent = Agent(
     name="Triage Agent",
-    instructions="Determine which agent is best suited to handle the user's request, and transfer the conversation to that agent.",
+    instructions=(
+        "Determine which agent is best suited to handle the user's request and transfer the conversation to that agent. "
+        "Never terminate the conversation yourself. After providing an answer, transfer to the clarifying agent so it can ask if the user needs anything else."
+    ),
     model=MODEL_NAME_1,
 )
 

--- a/main.py
+++ b/main.py
@@ -1,15 +1,20 @@
-"""Script to Analyse Data from the Triage Agent."""
-from agents import client, triage_agent
+"""Interactive script to analyse data using the triage agent."""
+
+from agents import client, triage_agent, ask_user
+
+
+def main() -> None:
+    """Run the triage agent in a loop and keep asking for new requests."""
+    user_message = ask_user("What would you like to do?")
+    while user_message.strip():
+        response = client.run(
+            agent=triage_agent,
+            messages=[{"role": "user", "content": user_message}],
+            debug=True,
+        )
+        print(response.messages[-1]["content"])
+        user_message = ask_user("Anything else I can help with? (Leave blank to exit)")
+
 
 if __name__ == "__main__":
-    response = client.run(
-        agent=triage_agent,
-        messages=[
-            {
-                "role": "user",
-                "content": "Zeige mir die letzten 1 stunde scd41_co2 und scd41_temperature",
-            }
-        ],
-        debug=True,
-    )
-    print(response.messages[-1]["content"])
+    main()


### PR DESCRIPTION
## Summary
- update clarifying agent instructions to verify if the user has more requests
- adjust triage agent instructions so it always hands off to the clarifying agent
- turn `main.py` into an interactive loop using `ask_user`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853db60d91c83329786bac965f93ff0