### PR TITLE
Fix missing data error

### DIFF
--- a/agents/data_specialist_agent.py
+++ b/agents/data_specialist_agent.py
@@ -5,8 +5,16 @@ from swarm import Agent
 from .common import MODEL_NAME_1
 
 
-def list_data_fields(data: dict) -> list:
-    """List all available fields in the provided dataset."""
+def list_data_fields(data: dict | None = None) -> list:
+    """Return the column names in the provided dataset.
+
+    When called without data, an empty list is returned instead of raising a
+    ``TypeError``. This makes the function more robust when the agent invokes it
+    without arguments.
+    """
+    if not data:
+        return []
+
     df = pd.DataFrame(data)
     return list(df.columns)
 

--- a/agents/data_specialist_agent.py
+++ b/agents/data_specialist_agent.py
@@ -19,8 +19,15 @@ def list_data_fields(data: dict | None = None) -> list:
     return list(df.columns)
 
 
-def filter_data(data: dict, filters: dict) -> dict:
-    """Filter the dataset based on provided criteria."""
+def filter_data(data: dict | None = None, filters: dict | None = None) -> dict:
+    """Return a subset of ``data`` that matches ``filters``.
+
+    When called without arguments, an empty dict is returned so the agent does
+    not raise a ``TypeError`` if no data is supplied.
+    """
+    if not data or not filters:
+        return {}
+
     df = pd.DataFrame(data)
     for field, condition in filters.items():
         df = df.query(condition)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -163,3 +163,10 @@ def test_list_data_fields_no_data():
 
     assert agents.list_data_fields() == []
 
+
+def test_filter_data_no_args():
+    import agents
+    importlib.reload(agents)
+
+    assert agents.filter_data() == {}
+

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -156,3 +156,10 @@ def test_influx_query_last_hour_defaults_measurement():
         called_query = mock_query_api.query.call_args.kwargs['query']
         assert 'r._measurement == "default_measure"' in called_query
 
+
+def test_list_data_fields_no_data():
+    import agents
+    importlib.reload(agents)
+
+    assert agents.list_data_fields() == []
+


### PR DESCRIPTION
## Summary
- avoid TypeError when `list_data_fields` is called without data
- test the new default behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853dd5e370c8332b2fc1454afe21f2c