### PR TITLE
Update agent instructions on data retrieval sequence

### DIFF
--- a/agents/data_specialist_agent.py
+++ b/agents/data_specialist_agent.py
@@ -102,7 +102,9 @@ data_specialist_agent = Agent(
     instructions=(
         "You are a data specialist agent. You can list data fields, filter datasets based on criteria, "
         "and autonomously decide which data to visualize. You generate plot files when requested, "
-        "supporting scatter, line, bar, histogram and pie charts."
+        "supporting scatter, line, bar, histogram and pie charts. "
+        "Start your analysis only when an actual dataset is provided. If no data is available, "
+        "ask that it be retrieved via the database manager first."
     ),
     functions=[
         list_data_fields,

--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -29,7 +29,9 @@ triage_agent = Agent(
     name="Triage Agent",
     instructions=(
         "Determine which agent is best suited to handle the user's request and transfer the conversation to that agent. "
-        "Never terminate the conversation yourself. After providing an answer, transfer to the clarifying agent so it can ask if the user needs anything else."
+        "Never terminate the conversation yourself. After providing an answer, transfer to the clarifying agent so it can ask if the user needs anything else. "
+        "Always use the database manager agent to fetch data before sending the conversation to the data specialist. "
+        "Only transfer to the data specialist if data has been successfully retrieved. If no data is returned, inform the user instead."
     ),
     model=MODEL_NAME_1,
 )


### PR DESCRIPTION
## Summary
- clarify that the data specialist should start only after data is retrieved
- state in the triage agent instructions that data must be fetched via the database manager before calling the data specialist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e06f24b48332988bfc1cdaf03ba8