### PR TITLE
Add persistent note storage for all agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ provider.
 
 ### Notes
 The `influx_query` function now automatically injects the configured bucket if the Flux query does not specify one or if the placeholder `INFLUX_BUCKET` is used. It also applies the configured measurement when no `_measurement` filter is present or when `MEASUREMENT` is used as a placeholder.
+The main script persists a short conversation history in `memory.json` so recent
+context is reused across agent calls. Agents can also store additional notes
+using the new `remember_note` function which writes to this memory file.
 
 ### Agents
 Each agent now resides in its own module under the `agents` package:
@@ -31,3 +34,4 @@ Each agent now resides in its own module under the `agents` package:
 - `data_specialist_agent.py` for data analysis and plotting
 - `clarifying_agent.py` for gathering missing user details
 - `triage_agent.py` that routes requests to the appropriate agent
+- `remember_note` helper allows any agent to persist important notes

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -22,6 +22,7 @@ from .data_specialist_agent import (
     data_specialist_agent,
 )
 from .clarifying_agent import ask_user, clarifying_agent
+from memory import remember_note
 from .triage_agent import (
     triage_agent,
     transfer_back_to_triage,
@@ -46,6 +47,7 @@ __all__ = [
     "list_data_fields",
     "filter_data",
     "visualize_data",
+    "remember_note",
     "ask_user",
     "influxDB_agent",
     "data_specialist_agent",

--- a/agents/clarifying_agent.py
+++ b/agents/clarifying_agent.py
@@ -1,5 +1,6 @@
 from swarm import Agent
 from .common import MODEL_NAME_1
+from memory import remember_note
 
 
 def ask_user(question: str) -> str:
@@ -13,6 +14,6 @@ clarifying_agent = Agent(
         "You help gather missing details and check if the user has further requests. "
         "Whenever more information is needed or a conversation ends, call the ask_user function to interact with the user."
     ),
-    functions=[ask_user],
+    functions=[ask_user, remember_note],
     model=MODEL_NAME_1,
 )

--- a/agents/data_specialist_agent.py
+++ b/agents/data_specialist_agent.py
@@ -3,6 +3,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from swarm import Agent
 from .common import MODEL_NAME_1
+from memory import remember_note
 
 
 def list_data_fields(data: dict) -> list:
@@ -110,6 +111,7 @@ data_specialist_agent = Agent(
         list_data_fields,
         filter_data,
         visualize_data,
+        remember_note,
     ],
     model=MODEL_NAME_1,
 )

--- a/agents/database_manager.py
+++ b/agents/database_manager.py
@@ -4,6 +4,7 @@ from influxdb_client import InfluxDBClient
 from datetime import datetime, timezone
 from swarm import Agent
 from .common import MODEL_NAME_1
+from memory import remember_note
 
 try:
     from config import (
@@ -157,6 +158,7 @@ influxDB_agent = Agent(
         influx_write_point,
         influx_delete_data,
         get_current_time,
+        remember_note,
     ],
     model=MODEL_NAME_1,
 )

--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -1,5 +1,6 @@
 from swarm import Agent
 from .common import MODEL_NAME_1
+from memory import remember_note
 from .database_manager import influxDB_agent
 from .data_specialist_agent import data_specialist_agent
 from .clarifying_agent import clarifying_agent
@@ -40,6 +41,7 @@ triage_agent.functions = [
     transfer_to_database_manager,
     transfer_to_data_specialist,
     transfer_to_clarifying_agent,
+    remember_note,
 ]
 
 # add transfer functions to other agents

--- a/main.py
+++ b/main.py
@@ -1,19 +1,28 @@
 """Interactive script to analyse data using the triage agent."""
 
 from agents import client, triage_agent, ask_user
+from memory import load_memory, save_memory, append_history
 
 
 def main() -> None:
-    """Run the triage agent in a loop and keep asking for new requests."""
+    """Run the triage agent in a loop, keeping a small conversation history."""
+    memory = load_memory()
     user_message = ask_user("What would you like to do?")
     while user_message.strip():
+        memory = append_history(memory, "user", user_message)
+        messages = memory.get("notes", []) + memory.get("history", [])
         response = client.run(
             agent=triage_agent,
-            messages=[{"role": "user", "content": user_message}],
+            messages=messages,
             debug=True,
         )
-        print(response.messages[-1]["content"])
-        user_message = ask_user("Anything else I can help with? (Leave blank to exit)")
+        assistant_reply = response.messages[-1]["content"]
+        print(assistant_reply)
+        memory = append_history(memory, "assistant", assistant_reply)
+        save_memory(memory)
+        user_message = ask_user(
+            "Anything else I can help with? (Leave blank to exit)"
+        )
 
 
 if __name__ == "__main__":

--- a/memory.py
+++ b/memory.py
@@ -1,0 +1,51 @@
+import json
+import os
+
+MEMORY_FILE = "memory.json"
+MAX_HISTORY = 10
+
+
+def load_memory() -> dict:
+    """Return stored history and notes from disk."""
+    if os.path.exists(MEMORY_FILE):
+        with open(MEMORY_FILE, "r", encoding="utf-8") as f:
+            try:
+                data = json.load(f)
+                if isinstance(data, list):
+                    return {"history": data, "notes": []}
+                if isinstance(data, dict):
+                    data.setdefault("history", [])
+                    data.setdefault("notes", [])
+                    return data
+            except json.JSONDecodeError:
+                pass
+    return {"history": [], "notes": []}
+
+
+def save_memory(memory: dict) -> None:
+    trimmed = {
+        "history": memory.get("history", [])[-MAX_HISTORY:],
+        "notes": memory.get("notes", []),
+    }
+    with open(MEMORY_FILE, "w", encoding="utf-8") as f:
+        json.dump(trimmed, f)
+
+
+def append_history(memory: dict, role: str, content: str) -> dict:
+    memory.setdefault("history", [])
+    memory["history"].append({"role": role, "content": content})
+    memory["history"] = memory["history"][-MAX_HISTORY:]
+    return memory
+
+
+def append_note(memory: dict, content: str) -> dict:
+    memory.setdefault("notes", [])
+    memory["notes"].append({"role": "system", "content": content})
+    return memory
+
+
+def remember_note(content: str) -> str:
+    memory = load_memory()
+    memory = append_note(memory, content)
+    save_memory(memory)
+    return "note saved"


### PR DESCRIPTION
## Summary
- extend `memory.py` to store conversation history and agent notes
- expose new `remember_note` helper via `agents.__init__`
- allow all agents to save notes by including the helper in their function lists
- update `main.py` to send stored notes and history to the triage agent
- document the new memory capability in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543c0e16c083329f1879754b34d2f5