### PR TITLE
Add global data cache with helper functions

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -13,15 +13,21 @@ from .database_manager import (
     influx_write_point,
     influx_delete_data,
     get_current_time,
+    influx_query_store,
     influxDB_agent,
 )
 from .data_specialist_agent import (
     list_data_fields,
     filter_data,
     visualize_data,
+    head_cached_data,
     data_specialist_agent,
 )
 from .clarifying_agent import ask_user, clarifying_agent
+from .data_store import (
+    store_cached_data,
+    get_cached_data,
+)
 from .triage_agent import (
     triage_agent,
     transfer_back_to_triage,
@@ -40,13 +46,17 @@ __all__ = [
     "influx_list_measurements",
     "influx_list_fields",
     "influx_query",
+    "influx_query_store",
     "influx_write_point",
     "influx_delete_data",
     "get_current_time",
     "list_data_fields",
     "filter_data",
     "visualize_data",
+    "head_cached_data",
     "ask_user",
+    "store_cached_data",
+    "get_cached_data",
     "influxDB_agent",
     "data_specialist_agent",
     "clarifying_agent",

--- a/agents/data_specialist_agent.py
+++ b/agents/data_specialist_agent.py
@@ -3,6 +3,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from swarm import Agent
 from .common import MODEL_NAME_1
+from .data_store import head_cached_data
 
 
 def list_data_fields(data: dict) -> list:
@@ -103,6 +104,7 @@ data_specialist_agent = Agent(
         "You are a data specialist agent. You can list data fields, filter datasets based on criteria, "
         "and autonomously decide which data to visualize. You generate plot files when requested, "
         "supporting scatter, line, bar, histogram and pie charts. "
+        "Retrieved data is cached globally. Use head_cached_data to inspect the first rows. "
         "Start your analysis only when an actual dataset is provided. If no data is available, "
         "ask that it be retrieved via the database manager first."
     ),
@@ -110,6 +112,7 @@ data_specialist_agent = Agent(
         list_data_fields,
         filter_data,
         visualize_data,
+        head_cached_data,
     ],
     model=MODEL_NAME_1,
 )

--- a/agents/data_store.py
+++ b/agents/data_store.py
@@ -1,0 +1,27 @@
+cached_data = None
+
+
+def store_cached_data(data):
+    """Store data in the global cache and return a status message."""
+    global cached_data
+    cached_data = data
+    length = len(data) if hasattr(data, "__len__") else 0
+    return {"status": "stored", "records": length}
+
+
+def get_cached_data():
+    """Return the cached dataset."""
+    return cached_data
+
+
+def head_cached_data(n: int = 10):
+    """Return the first ``n`` rows from the cached dataset."""
+    if cached_data is None:
+        return None
+    import pandas as pd
+
+    df = pd.DataFrame(cached_data)
+    return df.head(n).to_dict(orient="list")
+
+
+__all__ = ["store_cached_data", "get_cached_data", "head_cached_data", "cached_data"]

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -149,3 +149,28 @@ def test_get_current_time_returns_iso():
     assert isinstance(time_str, str)
     assert "T" in time_str
 
+
+
+def test_influx_query_store_caches_data():
+    with patch('agents.database_manager.InfluxDBClient') as mock_client_cls:
+        mock_client = MagicMock()
+        mock_query_api = MagicMock()
+        mock_query_api.query.return_value = []
+        mock_client.query_api.return_value = mock_query_api
+        mock_client_cls.return_value = mock_client
+
+        import agents
+        importlib.reload(agents)
+
+        with patch('agents.database_manager.store_cached_data') as mock_store:
+            agents.influx_query_store('fake')
+            mock_store.assert_called_once()
+
+
+def test_head_cached_data_returns_subset():
+    import agents
+    importlib.reload(agents)
+
+    agents.store_cached_data([{'num': i} for i in range(20)])
+    subset = agents.head_cached_data(5)
+    assert subset['num'] == list(range(5))


### PR DESCRIPTION
## Summary
- store query results in a new global cache
- allow Database Manager agent to fill the cache via `influx_query_store`
- enable Data Specialist agent to preview cached data
- export cache helpers in `agents.__init__`
- test caching logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543fb78d6c83329b0d8caad39c5992