### PR TITLE
Implement file-based cache for database queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ provider.
 ### Notes
 The `influx_query` function now automatically injects the configured bucket if the Flux query does not specify one or if the placeholder `INFLUX_BUCKET` is used. It also applies the configured measurement when no `_measurement` filter is present or when `MEASUREMENT` is used as a placeholder.
 
+Query results retrieved with `influx_query_store` are saved to `cached_data.json` by default. The data analyst can load this file directly for further processing.
+
 ### Agents
 Each agent now resides in its own module under the `agents` package:
 - `database_manager.py` for database management

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ provider.
 ### Notes
 The `influx_query` function now automatically injects the configured bucket if the Flux query does not specify one or if the placeholder `INFLUX_BUCKET` is used. It also applies the configured measurement when no `_measurement` filter is present or when `MEASUREMENT` is used as a placeholder.
 
-Query results retrieved with `influx_query_store` are saved to `cached_data.json` by default. The data analyst can load this file directly for further processing.
+Query results retrieved with `influx_query` are automatically saved to `cached_data.json` by default. The data analyst can load this file directly for further processing.
 
 ### Agents
 Each agent now resides in its own module under the `agents` package:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ provider.
 The `influx_query` function now automatically injects the configured bucket if the Flux query does not specify one or if the placeholder `INFLUX_BUCKET` is used. It also applies the configured measurement when no `_measurement` filter is present or when `MEASUREMENT` is used as a placeholder.
 
 Query results retrieved with `influx_query` are automatically saved to `cached_data.json` by default. The data analyst can load this file directly for further processing.
+Most agent functions also return a short descriptive message so other agents know what happened.
 
 ### Agents
 Each agent now resides in its own module under the `agents` package:

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -13,7 +13,6 @@ from .database_manager import (
     influx_write_point,
     influx_delete_data,
     get_current_time,
-    influx_query_store,
     influxDB_agent,
 )
 from .data_specialist_agent import (
@@ -27,6 +26,7 @@ from .clarifying_agent import ask_user, clarifying_agent
 from .data_store import (
     store_cached_data,
     get_cached_data,
+    CACHE_FILE,
 )
 from .triage_agent import (
     triage_agent,
@@ -46,7 +46,6 @@ __all__ = [
     "influx_list_measurements",
     "influx_list_fields",
     "influx_query",
-    "influx_query_store",
     "influx_write_point",
     "influx_delete_data",
     "get_current_time",
@@ -57,6 +56,7 @@ __all__ = [
     "ask_user",
     "store_cached_data",
     "get_cached_data",
+    "CACHE_FILE",
     "influxDB_agent",
     "data_specialist_agent",
     "clarifying_agent",

--- a/agents/data_specialist_agent.py
+++ b/agents/data_specialist_agent.py
@@ -3,7 +3,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from swarm import Agent
 from .common import MODEL_NAME_1
-from .data_store import head_cached_data
+from .data_store import head_cached_data, CACHE_FILE
 
 
 def list_data_fields(data: dict) -> list:
@@ -104,7 +104,8 @@ data_specialist_agent = Agent(
         "You are a data specialist agent. You can list data fields, filter datasets based on criteria, "
         "and autonomously decide which data to visualize. You generate plot files when requested, "
         "supporting scatter, line, bar, histogram and pie charts. "
-        "Retrieved data is cached globally. Use head_cached_data to inspect the first rows. "
+        "Retrieved data is cached in the file "
+        f"{CACHE_FILE}. Use head_cached_data to inspect the first rows. "
         "Start your analysis only when an actual dataset is provided. If no data is available, "
         "ask that it be retrieved via the database manager first."
     ),

--- a/agents/data_specialist_agent.py
+++ b/agents/data_specialist_agent.py
@@ -6,22 +6,27 @@ from .common import MODEL_NAME_1
 from .data_store import head_cached_data, CACHE_FILE
 
 
-def list_data_fields(data: dict) -> list:
-    """List all available fields in the provided dataset."""
+def list_data_fields(data: dict) -> dict:
+    """List all available fields in the provided dataset with a message."""
     df = pd.DataFrame(data)
-    return list(df.columns)
+    fields = list(df.columns)
+    return {"message": f"Found {len(fields)} fields.", "fields": fields}
 
 
 def filter_data(data: dict, filters: dict) -> dict:
-    """Filter the dataset based on provided criteria."""
+    """Filter the dataset based on provided criteria and describe the result."""
     df = pd.DataFrame(data)
     for field, condition in filters.items():
         df = df.query(condition)
-    return df.to_dict(orient="list")
+    result = df.to_dict(orient="list")
+    return {
+        "message": f"Filtered data with {len(filters)} conditions resulting in {len(df)} rows.",
+        "data": result,
+    }
 
 
-def visualize_data(data: dict, plot_type: str | None = None, filename: str | None = None) -> str:
-    """Generate a plot from the data and save it to a file."""
+def visualize_data(data: dict, plot_type: str | None = None, filename: str | None = None) -> dict:
+    """Generate a plot from the data, save it, and return a summary message."""
     df = pd.DataFrame(data)
 
     numeric_cols = df.select_dtypes(include="number").columns.tolist()
@@ -95,7 +100,7 @@ def visualize_data(data: dict, plot_type: str | None = None, filename: str | Non
     filepath = os.path.join(output_dir, filename)
     plt.savefig(filepath)
     plt.close()
-    return filepath
+    return {"message": f"Plot saved to {filepath}", "file": filepath}
 
 
 data_specialist_agent = Agent(

--- a/agents/data_store.py
+++ b/agents/data_store.py
@@ -30,14 +30,18 @@ def get_cached_data():
 
 
 def head_cached_data(n: int = 10):
-    """Return the first ``n`` rows from the cached dataset."""
+    """Return the first ``n`` rows from the cached dataset along with a message."""
     data = get_cached_data()
     if data is None:
-        return None
+        return {"message": "No cached data available.", "data": None}
     import pandas as pd
 
     df = pd.DataFrame(data)
-    return df.head(n).to_dict(orient="list")
+    subset = df.head(n).to_dict(orient="list")
+    return {
+        "message": f"Returned the first {n} rows of cached data.",
+        "data": subset,
+    }
 
 
 __all__ = [

--- a/agents/database_manager.py
+++ b/agents/database_manager.py
@@ -109,8 +109,8 @@ def influx_query(flux_query: str, measurement: str | None = None):
     ]
 
 
-def influx_query_store(flux_query: str, measurement: str | None = None):
-    """Run a query and store the result in the global cache."""
+def influx_query_store(flux_query: str, measurement: str | None = None) -> str:
+    """Run a query, cache the result to disk and return a confirmation message."""
     data = influx_query(flux_query, measurement)
     return store_cached_data(data)
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -145,9 +145,9 @@ def test_get_current_time_returns_iso():
     import agents
     importlib.reload(agents)
 
-    time_str = agents.get_current_time()
-    assert isinstance(time_str, str)
-    assert "T" in time_str
+    time_info = agents.get_current_time()
+    assert "time" in time_info
+    assert "T" in time_info["time"]
 
 
 
@@ -173,4 +173,4 @@ def test_head_cached_data_returns_subset():
 
     agents.store_cached_data([{'num': i} for i in range(20)])
     subset = agents.head_cached_data(5)
-    assert subset['num'] == list(range(5))
+    assert subset["data"]["num"] == list(range(5))

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -151,7 +151,7 @@ def test_get_current_time_returns_iso():
 
 
 
-def test_influx_query_store_caches_data():
+def test_influx_query_caches_data():
     with patch('agents.database_manager.InfluxDBClient') as mock_client_cls:
         mock_client = MagicMock()
         mock_query_api = MagicMock()
@@ -163,7 +163,7 @@ def test_influx_query_store_caches_data():
         importlib.reload(agents)
 
         with patch('agents.database_manager.store_cached_data') as mock_store:
-            agents.influx_query_store('fake')
+            agents.influx_query('fake')
             mock_store.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- persist query results to `cached_data.json`
- load cached data from disk when needed
- return message string when caching query results

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854463ddb388332b8a6ccd4637f4fc7